### PR TITLE
🍻 update user state after `Action.GETREADY`

### DIFF
--- a/src/main/kotlin/eu/boxwork/dhbw/capturethecode/model/GameGround.kt
+++ b/src/main/kotlin/eu/boxwork/dhbw/capturethecode/model/GameGround.kt
@@ -255,6 +255,7 @@ class GameGround (
                 // user may only get up
                 if (action==Action.GETREADY) {
                     actions[user] = action
+                    states[user] = PlayerState.READY
                     events.add(Event(round, players[user]?.name,null, "gets ready again."))
                 }
                 else {


### PR DESCRIPTION
## Issue
`PlayerState` did not seem to get updated after `Action.READY`, players remained `ON_GROUND`. Could not test locally.